### PR TITLE
fix(platform): update the provider path to use the correct name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ variable "api_token_secret_key" {
 terraform {
   required_providers {
     stax = {
-      source = "registry.terraform.io/stax/stax"
+      source = "registry.terraform.io/stax-labs/stax"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ variable "api_token_secret_key" {
 terraform {
   required_providers {
     stax = {
-      source = "registry.terraform.io/stax/stax"
+      source = "registry.terraform.io/stax-labs/stax"
     }
   }
 }

--- a/examples/data-sources/stax_account_types/main.tf
+++ b/examples/data-sources/stax_account_types/main.tf
@@ -13,7 +13,7 @@ variable "api_token_secret_key" {
 terraform {
   required_providers {
     stax = {
-      source = "registry.terraform.io/stax/stax"
+      source = "registry.terraform.io/stax-labs/stax"
     }
   }
 }

--- a/examples/data-sources/stax_accounts/main.tf
+++ b/examples/data-sources/stax_accounts/main.tf
@@ -13,7 +13,7 @@ variable "api_token_secret_key" {
 terraform {
   required_providers {
     stax = {
-      source = "registry.terraform.io/stax/stax"
+      source = "registry.terraform.io/stax-labs/stax"
     }
   }
 }

--- a/examples/data-sources/stax_groups/main.tf
+++ b/examples/data-sources/stax_groups/main.tf
@@ -13,7 +13,7 @@ variable "api_token_secret_key" {
 terraform {
   required_providers {
     stax = {
-      source = "registry.terraform.io/stax/stax"
+      source = "registry.terraform.io/stax-labs/stax"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -13,7 +13,7 @@ variable "api_token_secret_key" {
 terraform {
   required_providers {
     stax = {
-      source = "registry.terraform.io/stax/stax"
+      source = "registry.terraform.io/stax-labs/stax"
     }
   }
 }

--- a/examples/resources/stax_account/main.tf
+++ b/examples/resources/stax_account/main.tf
@@ -13,7 +13,7 @@ variable "api_token_secret_key" {
 terraform {
   required_providers {
     stax = {
-      source = "registry.terraform.io/stax/stax"
+      source = "registry.terraform.io/stax-labs/stax"
     }
   }
 }

--- a/examples/resources/stax_account_type/main.tf
+++ b/examples/resources/stax_account_type/main.tf
@@ -13,7 +13,7 @@ variable "api_token_secret_key" {
 terraform {
   required_providers {
     stax = {
-      source = "registry.terraform.io/stax/stax"
+      source = "registry.terraform.io/stax-labs/stax"
     }
   }
 }

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	opts := providerserver.ServeOpts{
 		// TODO: Update this string with the published name of your provider.
-		Address: "registry.terraform.io/stax/stax",
+		Address: "registry.terraform.io/stax-labs/stax",
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
After going through the provider publishing process I realised that org name is based on the github org which hosts the provider. :facepalm:
