### PR TITLE
chore(platform): update all the examples and link to stax documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ NOTE: This provider is built with the assumption that you are a Stax customer an
 
 ```terraform
 variable "installation" {
-  description = "installation region name"
+  description = "Stax Short Installation ID for your Stax tenancy's control plane"
 }
 
 variable "api_token_access_key" {
-  description = "api token access key"
+  description = "Stax API Token Access Key"
 }
 
 variable "api_token_secret_key" {
-  description = "api token secret key"
+  description = "Stax API Token Secret Key"
 }
 
 terraform {
@@ -57,6 +57,40 @@ provider "stax" {
 1. The Terraform data sources currently only utilize the first page from the Stax API. However, this will change once we develop a strategy to manage large results while minimizing the impact on the Stax API.
 
 # Development
+
+To build the terraform provider locally you will require.
+
+* Terraform >= 1.0
+* Go >= 1.20
+
+To build and install the provider use `make install`.
+
+To run the acceptance tests use `make testacc`
+
+To manually test the examples you will need to the provider path and setup some environment variables, then you will be able to use the targets in the `GNUMakefile` for testing.
+## Overriding the provider for local development
+
+You'll need to add a provider override to your `~/.terraformrc`. Documentation around using this file can be found [here](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers). See below for an example of a `.terraformrc` file set up for plugin override.
+
+Update the `CHANGE_ME_TO_GO_BIN` to `go env GOPATH` with `\bin` appended, shell command below will emit the correct value.
+
+```
+echo $(go env GOPATH)\bin
+``
+
+```hcl
+provider_installation {
+
+        dev_overrides {
+                "stax-labs/stax" = "CHANGE_ME_TO_GO_BIN"
+        }
+
+        direct {}
+}
+
+```
+
+## Manual Testing Environment Variables
 
 To provide the required secrets during development and integration testing some environment variables are required to run examples. These can be configured using an `.envrc` file which is loaded by [direnv](https://direnv.net/).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,25 +7,30 @@ description: |-
 
 # Stax Provider
 
-The Stax terraform provider is used to interact with resources supported by Stax. The provider needs to be configured with an [API Token](https://www.stax.io/developer/api-tokens/) before it can be used.
+The Stax terraform provider is used to interact with resources supported by Stax.
 
 ## Getting Started
 
-TBA
+If your new to terraform then the hashicorp developer site has a great guide to getting up and running [Install Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli) with AWS.
+
+Once you have terraform installed you will require the following.
+
+1. An [API Token](https://www.stax.io/developer/api-tokens/) which can be created in the stax console. The token must have the `Read Only (API)` role to read using datasources, or `Admin (API)` role to create and manage accounts.
+2. The [Stax Short Installation ID](https://support.stax.io/hc/en-us/articles/4537150525071-Stax-Installation-Regions) which hosts your Stax tenancy.
 
 ## Example Usage
 
 ```terraform
 variable "installation" {
-  description = "installation name"
+  description = "Stax Short Installation ID for your Stax tenancy's control plane"
 }
 
 variable "api_token_access_key" {
-  description = "api token access key"
+  description = "Stax API Token Access Key"
 }
 
 variable "api_token_secret_key" {
-  description = "api token secret key"
+  description = "Stax API Token Secret Key"
 }
 
 terraform {
@@ -48,6 +53,6 @@ provider "stax" {
 
 ### Optional
 
-- `api_token_access_key` (String) API Token Access Key
-- `api_token_secret_key` (String) API Token Secret Key
-- `installation` (String) Stax Installation Region
+- `api_token_access_key` (String) Stax [API Token](https://www.stax.io/developer/api-tokens/) Access Key
+- `api_token_secret_key` (String) Stax [API Token](https://www.stax.io/developer/api-tokens/) Secret Key
+- `installation` (String) [Stax Short Installation ID](https://support.stax.io/hc/en-us/articles/4537150525071-Stax-Installation-Regions) for your Stax tenancy's control plane

--- a/examples/data-sources/stax_account_types/main.tf
+++ b/examples/data-sources/stax_account_types/main.tf
@@ -1,13 +1,13 @@
 variable "installation" {
-  description = "installation name"
+  description = "Stax Short Installation ID for your Stax tenancy's control plane"
 }
 
 variable "api_token_access_key" {
-  description = "api token access key"
+  description = "Stax API Token Access Key"
 }
 
 variable "api_token_secret_key" {
-  description = "api token secret key"
+  description = "Stax API Token Secret Key"
 }
 
 terraform {

--- a/examples/data-sources/stax_accounts/main.tf
+++ b/examples/data-sources/stax_accounts/main.tf
@@ -1,13 +1,13 @@
 variable "installation" {
-  description = "installation name"
+  description = "Stax Short Installation ID for your Stax tenancy's control plane"
 }
 
 variable "api_token_access_key" {
-  description = "api token access key"
+  description = "Stax API Token Access Key"
 }
 
 variable "api_token_secret_key" {
-  description = "api token secret key"
+  description = "Stax API Token Secret Key"
 }
 
 terraform {

--- a/examples/data-sources/stax_groups/main.tf
+++ b/examples/data-sources/stax_groups/main.tf
@@ -1,13 +1,13 @@
 variable "installation" {
-  description = "installation name"
+  description = "Stax Short Installation ID for your Stax tenancy's control plane"
 }
 
 variable "api_token_access_key" {
-  description = "api token access key"
+  description = "Stax API Token Access Key"
 }
 
 variable "api_token_secret_key" {
-  description = "api token secret key"
+  description = "Stax API Token Secret Key"
 }
 
 terraform {

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,13 +1,13 @@
 variable "installation" {
-  description = "installation name"
+  description = "Stax Short Installation ID for your Stax tenancy's control plane"
 }
 
 variable "api_token_access_key" {
-  description = "api token access key"
+  description = "Stax API Token Access Key"
 }
 
 variable "api_token_secret_key" {
-  description = "api token secret key"
+  description = "Stax API Token Secret Key"
 }
 
 terraform {

--- a/examples/resources/stax_account/main.tf
+++ b/examples/resources/stax_account/main.tf
@@ -1,13 +1,13 @@
 variable "installation" {
-  description = "installation name"
+  description = "Stax Short Installation ID for your Stax tenancy's control plane"
 }
 
 variable "api_token_access_key" {
-  description = "api token access key"
+  description = "Stax API Token Access Key"
 }
 
 variable "api_token_secret_key" {
-  description = "api token secret key"
+  description = "Stax API Token Secret Key"
 }
 
 terraform {

--- a/examples/resources/stax_account_type/main.tf
+++ b/examples/resources/stax_account_type/main.tf
@@ -1,13 +1,13 @@
 variable "installation" {
-  description = "installation name"
+  description = "Stax Short Installation ID for your Stax tenancy's control plane"
 }
 
 variable "api_token_access_key" {
-  description = "api token access key"
+  description = "Stax API Token Access Key"
 }
 
 variable "api_token_secret_key" {
-  description = "api token secret key"
+  description = "Stax API Token Secret Key"
 }
 
 terraform {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -43,15 +43,15 @@ func (p *StaxProvider) Schema(ctx context.Context, req provider.SchemaRequest, r
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"installation": schema.StringAttribute{
-				MarkdownDescription: "Stax Installation Region",
+				MarkdownDescription: "[Stax Short Installation ID](https://support.stax.io/hc/en-us/articles/4537150525071-Stax-Installation-Regions) for your Stax tenancy's control plane",
 				Optional:            true,
 			},
 			"api_token_access_key": schema.StringAttribute{
-				MarkdownDescription: "API Token Access Key",
+				MarkdownDescription: "Stax [API Token](https://www.stax.io/developer/api-tokens/) Access Key",
 				Optional:            true,
 			},
 			"api_token_secret_key": schema.StringAttribute{
-				MarkdownDescription: "API Token Secret Key",
+				MarkdownDescription: "Stax [API Token](https://www.stax.io/developer/api-tokens/) Secret Key",
 				Optional:            true,
 			},
 		},

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -7,11 +7,16 @@ description: |-
 
 # Stax Provider
 
-The Stax terraform provider is used to interact with resources supported by Stax. The provider needs to be configured with an [API Token](https://www.stax.io/developer/api-tokens/) before it can be used.
+The Stax terraform provider is used to interact with resources supported by Stax.
 
 ## Getting Started
 
-TBA
+If your new to terraform then the hashicorp developer site has a great guide to getting up and running [Install Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli) with AWS.
+
+Once you have terraform installed you will require the following.
+
+1. An [API Token](https://www.stax.io/developer/api-tokens/) which can be created in the stax console. The token must have the `Read Only (API)` role to read using datasources, or `Admin (API)` role to create and manage accounts.
+2. The [Stax Short Installation ID](https://support.stax.io/hc/en-us/articles/4537150525071-Stax-Installation-Regions) which hosts your Stax tenancy.
 
 ## Example Usage
 


### PR DESCRIPTION
This attempts to link everything to the canonical source for terminology while not breaking everything.
