### PR TITLE
fix(accounts): resolved issue with API return zero results

### DIFF
--- a/internal/api/staxsdk/client_test.go
+++ b/internal/api/staxsdk/client_test.go
@@ -62,6 +62,33 @@ func TestClient_PublicReadConfig(t *testing.T) {
 	assert.Equal(&models.PublicReadConfig{}, publicConfigResp.JSON200)
 }
 
+func TestClient_AccountReadByID(t *testing.T) {
+	assert := require.New(t)
+	accountID := "b549185e-0fd7-44cf-a7b5-0751c720c0f0"
+
+	testClient, clientWithResponsesMock := NewTestClient(t)
+
+	accounts := &models.AccountsReadAccounts{
+		Accounts: []models.Account{
+			{Id: &accountID},
+		},
+	}
+
+	clientWithResponsesMock.On("AccountsReadAccountWithResponse",
+		mock.AnythingOfType("*context.emptyCtx"),
+		accountID,
+		mock.AnythingOfType("*models.AccountsReadAccountParams"),
+		mock.AnythingOfType("client.RequestEditorFn"),
+	).Return(&client.AccountsReadAccountResp{
+		JSON200:      accounts,
+		HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+	}, nil)
+
+	accountResp, err := testClient.AccountReadByID(context.TODO(), accountID)
+	assert.NoError(err)
+	assert.Equal(accounts, accountResp.JSON200)
+}
+
 func TestClient_AccountCreate(t *testing.T) {
 	assert := require.New(t)
 
@@ -91,6 +118,33 @@ func TestClient_AccountCreate(t *testing.T) {
 	assert.NoError(err)
 
 	assert.Equal("test", *createResp.JSON200.TaskId)
+}
+
+func TestClient_AccountTypeReadById(t *testing.T) {
+	assert := require.New(t)
+	accountTypeID := "b549185e-0fd7-44cf-a7b5-0751c720c0f0"
+
+	testClient, clientWithResponsesMock := NewTestClient(t)
+
+	accountTypes := &models.AccountsReadAccountTypes{
+		AccountTypes: []models.AccountType{
+			{Id: &accountTypeID},
+		},
+	}
+
+	clientWithResponsesMock.On("AccountsReadAccountTypeWithResponse",
+		mock.AnythingOfType("*context.emptyCtx"),
+		accountTypeID,
+		mock.AnythingOfType("*models.AccountsReadAccountTypeParams"),
+		mock.AnythingOfType("client.RequestEditorFn"),
+	).Return(&client.AccountsReadAccountTypeResp{
+		JSON200:      accountTypes,
+		HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+	}, nil)
+
+	accountTypeResp, err := testClient.AccountTypeReadById(context.TODO(), accountTypeID)
+	assert.NoError(err)
+	assert.Equal(accountTypes, accountTypeResp.JSON200)
 }
 
 func TestClient_GroupRead(t *testing.T) {

--- a/internal/provider/account_resource_test.go
+++ b/internal/provider/account_resource_test.go
@@ -31,8 +31,10 @@ func TestAccountResource(t *testing.T) {
 
 	si := mocks.NewServerInterface(t)
 
+	accountID := "f646e0cf-840c-401a-933c-1ef3432b5a37"
+
 	si.On("AccountsCreateAccount", mock.AnythingOfType("*echo.context")).Return(func(c echo.Context) error {
-		return c.JSON(200, &models.AccountsCreateAccountResponse{TaskId: aws.String("4f2e7318-1e25-4b62-84b5-1cd701042760")})
+		return c.JSON(200, &models.AccountsCreateAccountResponse{TaskId: aws.String(accountID)})
 	})
 
 	si.On("TasksReadTask", mock.AnythingOfType("*echo.context"), mock.AnythingOfType("string")).Return(func(c echo.Context, taskId string) error {
@@ -50,11 +52,11 @@ func TestAccountResource(t *testing.T) {
 		})
 	})
 
-	si.On("AccountsReadAccounts", mock.AnythingOfType("*echo.context"), mock.AnythingOfType("models.AccountsReadAccountsParams")).Return(func(c echo.Context, params models.AccountsReadAccountsParams) error {
+	si.On("AccountsReadAccount", mock.AnythingOfType("*echo.context"), accountID, mock.AnythingOfType("models.AccountsReadAccountParams")).Return(func(c echo.Context, accountID string, params models.AccountsReadAccountParams) error {
 		return c.JSON(200, &models.AccountsReadAccounts{
 			Accounts: []models.Account{
 				{
-					Id:          aws.String("f646e0cf-840c-401a-933c-1ef3432b5a37"),
+					Id:          aws.String(accountID),
 					Name:        "presentation-dev",
 					Status:      (*models.AccountStatus)(aws.String("ACTIVE")),
 					AccountType: aws.String("production"),

--- a/internal/provider/account_type_resource_test.go
+++ b/internal/provider/account_type_resource_test.go
@@ -34,7 +34,7 @@ func TestAccountTypeResource(t *testing.T) {
 		}})
 	})
 
-	si.On("AccountsReadAccountTypes", mock.AnythingOfType("*echo.context"), mock.AnythingOfType("models.AccountsReadAccountTypesParams")).Return(func(c echo.Context, params models.AccountsReadAccountTypesParams) error {
+	si.On("AccountsReadAccountType", mock.AnythingOfType("*echo.context"), accountTypeID, mock.AnythingOfType("models.AccountsReadAccountTypeParams")).Return(func(c echo.Context, accountTypeID string, params models.AccountsReadAccountTypeParams) error {
 		return c.JSON(200, &models.AccountsReadAccountTypes{
 			AccountTypes: []models.AccountType{
 				{


### PR DESCRIPTION
During the testing of import some issues returning zero results rather than not found came to light. These have now been resolved and clean error messages for the user have been added.

Also did some tidy up of calls to the API using the correct endpoint, and removed some duplication from the account types resource.
