### PR TITLE
fix(teams): change user identifier list to a set in group membership

### DIFF
--- a/docs/resources/group_membership.md
+++ b/docs/resources/group_membership.md
@@ -38,4 +38,4 @@ resource "stax_group_membership" "cost-data-scientist" {
 
 ### Optional
 
-- `user_ids` (List of String) Array of IDs of Stax Users belonging to the Group
+- `user_ids` (Set of String) Array of IDs of Stax Users belonging to the Group

--- a/internal/provider/group_membership_resource.go
+++ b/internal/provider/group_membership_resource.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -26,7 +26,7 @@ var _ resource.ResourceWithImportState = &GroupMembershipResource{}
 
 type GroupMembershipResourceModel struct {
 	ID       types.String `tfsdk:"id"`
-	UsersIDs types.List   `tfsdk:"user_ids"`
+	UsersIDs types.Set    `tfsdk:"user_ids"`
 }
 
 func NewGroupMembershipResource() resource.Resource {
@@ -51,12 +51,12 @@ func (r *GroupMembershipResource) Schema(ctx context.Context, req resource.Schem
 				Required:            true,
 				MarkdownDescription: "Group identifier",
 			},
-			"user_ids": schema.ListAttribute{
+			"user_ids": schema.SetAttribute{
 				MarkdownDescription: "Array of IDs of Stax Users belonging to the Group",
 				ElementType:         types.StringType,
 				Optional:            true,
-				Validators: []validator.List{
-					listvalidator.SizeAtLeast(1),
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
 				},
 			},
 		},
@@ -254,11 +254,11 @@ func (r *GroupMembershipResource) readGroup(ctx context.Context, groupID string,
 			slices.Sort(*group.Users)
 		}
 
-		groupList, d := types.ListValueFrom(ctx, types.StringType, group.Users)
+		usersList, d := types.SetValueFrom(ctx, types.StringType, group.Users)
 		diags.Append(d...)
 
 		data.ID = types.StringValue(*group.Id)
-		data.UsersIDs = groupList
+		data.UsersIDs = usersList
 	}
 
 	return diags


### PR DESCRIPTION
Was using the wrong data structure to store user identifiers, list is an ordered structure, what I wanted was a set which is a list of unique values which doesn't care about order.

This fixes some issues around adding and updating the list of user identifers. 😅
