### PR TITLE
docs(platform): ensure we have some links to the help documentation

### DIFF
--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -3,12 +3,12 @@
 page_title: "stax_account Resource - terraform-provider-stax"
 subcategory: ""
 description: |-
-  Account resource
+  Account resource. Stax Accounts https://support.stax.io/hc/en-us/articles/4453778959503-About-Accounts allows you to securely and easily create, view and centrally manage your AWS Accounts and get started deploying applications.
 ---
 
 # stax_account (Resource)
 
-Account resource
+Account resource. [Stax Accounts](https://support.stax.io/hc/en-us/articles/4453778959503-About-Accounts) allows you to securely and easily create, view and centrally manage your AWS Accounts and get started deploying applications.
 
 ## Example Usage
 
@@ -31,17 +31,17 @@ resource "stax_account" "presentation-dev" {
 
 ### Required
 
-- `name` (String) The name of the account
+- `name` (String) The name of the stax account
 
 ### Optional
 
-- `account_type_id` (String) The account type identifier for the account
+- `account_type_id` (String) The account type identifier for the stax account
 - `aws_account_alias` (String) The aws account alias for the stax account
-- `tags` (Map of String) Account tags
+- `tags` (Map of String) The tags associated with the stax account
 
 ### Read-Only
 
-- `account_type` (String) The account type for the account
+- `account_type` (String) The account type for the stax account
 - `aws_account_id` (String) The aws account identifier for the stax account
 - `id` (String) Account identifier
 - `status` (String) Account Status

--- a/docs/resources/account_type.md
+++ b/docs/resources/account_type.md
@@ -3,12 +3,12 @@
 page_title: "stax_account_type Resource - terraform-provider-stax"
 subcategory: ""
 description: |-
-  Account Type resource
+  Account Type resource. Stax Account Types https://support.stax.io/hc/en-us/articles/4454028359567-Manage-Account-Types to group your accounts and apply Permission Sets.
 ---
 
 # stax_account_type (Resource)
 
-Account Type resource
+Account Type resource. [Stax Account Types](https://support.stax.io/hc/en-us/articles/4454028359567-Manage-Account-Types) to group your accounts and apply Permission Sets.
 
 ## Example Usage
 
@@ -28,9 +28,9 @@ resource "stax_account_type" "production" {
 
 ### Required
 
-- `name` (String) The name of the account type
+- `name` (String) The name of the stax account type
 
 ### Read-Only
 
-- `id` (String) Account type identifier
+- `id` (String) Account Type identifier
 - `status` (String) The status of the stax account type

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -3,12 +3,12 @@
 page_title: "stax_group Resource - terraform-provider-stax"
 subcategory: ""
 description: |-
-  Stax Group resource
+  Stax Group resource. Stax Groups https://support.stax.io/hc/en-us/articles/4445008125455-Manage-Groups govern access to AWS accounts managed by Stax
 ---
 
 # stax_group (Resource)
 
-Stax Group resource
+Stax Group resource. [Stax Groups](https://support.stax.io/hc/en-us/articles/4445008125455-Manage-Groups) govern access to AWS accounts managed by Stax
 
 ## Example Usage
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -3,12 +3,12 @@
 page_title: "stax_user Resource - terraform-provider-stax"
 subcategory: ""
 description: |-
-  Stax User resource
+  Stax User resource. Stax Users https://support.stax.io/hc/en-us/articles/4445031773711-Manage-Users allows you to manage users details for non federated logins.
 ---
 
 # stax_user (Resource)
 
-Stax User resource
+Stax User resource. [Stax Users](https://support.stax.io/hc/en-us/articles/4445031773711-Manage-Users) allows you to manage users details for non federated logins.
 
 ## Example Usage
 

--- a/internal/provider/account_resource.go
+++ b/internal/provider/account_resource.go
@@ -49,7 +49,7 @@ func (r *AccountResource) Metadata(ctx context.Context, req resource.MetadataReq
 
 func (r *AccountResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Account resource",
+		MarkdownDescription: "Account resource. [Stax Accounts](https://support.stax.io/hc/en-us/articles/4453778959503-About-Accounts) allows you to securely and easily create, view and centrally manage your AWS Accounts and get started deploying applications.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -60,18 +60,18 @@ func (r *AccountResource) Schema(ctx context.Context, req resource.SchemaRequest
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "The name of the account",
+				MarkdownDescription: "The name of the stax account",
 				Required:            true,
 			},
 			"account_type_id": schema.StringAttribute{
-				MarkdownDescription: "The account type identifier for the account",
+				MarkdownDescription: "The account type identifier for the stax account",
 				Optional:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"account_type": schema.StringAttribute{
-				MarkdownDescription: "The account type for the account",
+				MarkdownDescription: "The account type for the stax account",
 				Computed:            true,
 			},
 			"status": schema.StringAttribute{
@@ -87,7 +87,7 @@ func (r *AccountResource) Schema(ctx context.Context, req resource.SchemaRequest
 				Optional:            true,
 			},
 			"tags": schema.MapAttribute{
-				MarkdownDescription: "Account tags",
+				MarkdownDescription: "The tags associated with the stax account",
 				Optional:            true,
 				ElementType:         types.StringType,
 			},

--- a/internal/provider/account_type_resource.go
+++ b/internal/provider/account_type_resource.go
@@ -41,18 +41,18 @@ func (r *AccountTypeResource) Metadata(ctx context.Context, req resource.Metadat
 
 func (r *AccountTypeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Account Type resource",
+		MarkdownDescription: "Account Type resource. [Stax Account Types](https://support.stax.io/hc/en-us/articles/4454028359567-Manage-Account-Types) to group your accounts and apply Permission Sets.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Account type identifier",
+				MarkdownDescription: "Account Type identifier",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "The name of the account type",
+				MarkdownDescription: "The name of the stax account type",
 				Required:            true,
 			},
 			"status": schema.StringAttribute{

--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -41,7 +41,7 @@ func (r *GroupResource) Metadata(ctx context.Context, req resource.MetadataReque
 
 func (r *GroupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Stax Group resource",
+		MarkdownDescription: "Stax Group resource. [Stax Groups](https://support.stax.io/hc/en-us/articles/4445008125455-Manage-Groups) govern access to AWS accounts managed by Stax",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -53,7 +53,7 @@ func (r *UserResource) Metadata(ctx context.Context, req resource.MetadataReques
 
 func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Stax User resource",
+		MarkdownDescription: "Stax User resource. [Stax Users](https://support.stax.io/hc/en-us/articles/4445031773711-Manage-Users) allows you to manage users details for non federated logins.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{


### PR DESCRIPTION
I have added some reference links to the resource documentation to help users learn about the different functions of stax.
