### PR TITLE
docs(support): update instructions for requesting support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @stax-labs/stax-developers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,28 @@
 # See GitHub's documentation for more information on this file:
 # https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
 version: 2
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "Australia/Melbourne"
+    groups:
+      all-actions:
+        patterns:
+          - "*"
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "Australia/Melbourne"
+    groups:
+      all-go-modules:
+        patterns:
+          - "*"

--- a/README.md
+++ b/README.md
@@ -120,6 +120,6 @@ For more information on contributing the to the Stax Go SDK, please see our [gui
 
 # Getting Help
 
-* If you're having trouble using the Stax SDK, please refer to our [documentation](https://www.stax.io/developer/api-tokens/).<br>
-* If you've encountered an issue or found a bug, please [open an issue](https://github.com/stax-labs/terraform-provider-stax/issues).<br>
+* If you're having trouble using the Stax SDK, please refer to our [documentation](https://support.stax.io/hc/en-us/articles/4447453523343-Using-the-Stax-API).
+* If you've encountered an issue or found a bug, please [open an issue](https://support.stax.io/hc/en-us/articles/4443377429647-Raise-a-Support-Case). Please include [trace-level logs](https://support.hashicorp.com/hc/en-us/articles/360001113727-Enabling-trace-level-logs-in-Terraform-CLI-Cloud-or-Enterprise) where possible.
 * For any other requests, please contact [Stax support](mailto:support@stax.io).


### PR DESCRIPTION
- update README to direct users to log a Stax support ticket instead of a Github issue
- add CODEOWNERS
- configure dependabot to group non-security updates into weekly digests